### PR TITLE
fix: use window.location.origin for display URL and QR code

### DIFF
--- a/components/display/RoomLobby.tsx
+++ b/components/display/RoomLobby.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useState } from "react";
 import { QRCodeSVG } from "qrcode.react";
 import type { Player } from "@/lib/types";
 
@@ -10,15 +10,14 @@ interface RoomLobbyProps {
 }
 
 export function RoomLobby({ roomCode, players }: RoomLobbyProps) {
-  // Use window.location.origin to get the correct URL in any environment
-  // This works for localhost, Vercel preview, and production
-  // Using useMemo since this is a computed value that doesn't change
-  const appUrl: string = useMemo(() => {
+  // Get the correct URL for any environment (localhost, Vercel preview, production)
+  // Using useState lazy initializer - guaranteed to run exactly once
+  const [appUrl] = useState<string>(() => {
     if (typeof window !== "undefined") {
       return window.location.origin;
     }
     return "";
-  }, []);
+  });
 
   const joinUrl = appUrl ? `${appUrl}/play?code=${roomCode}` : "";
 


### PR DESCRIPTION
## Summary

Fixes the display view showing incorrect URLs:
- **Before:** URL showed `localhost:3000/play` in production
- **Before:** QR code linked to `undefined/play?code=XXXX`
- **After:** Both use `window.location.origin` which works in all environments

## Root Cause

The previous implementation tried to use:
1. `NEXT_PUBLIC_LH_PARTY_APP_URL` - Not configured in Vercel
2. `VERCEL_URL` - Server-only env var, unavailable in client components

Both were `undefined`, causing fallback to hardcoded `localhost:3000`.

## Solution

Use `window.location.origin` with a lazy useState initializer:
- Automatically correct in localhost, Vercel preview, and production
- No environment variable configuration needed
- Handles SSR gracefully with empty string fallback
- Shows "Loading..." placeholder until URL is available

## Test Plan

- [ ] Local: Display shows `http://localhost:3000/play`
- [ ] Local: QR code links to `http://localhost:3000/play?code=XXXX`
- [ ] Production: Display shows `https://localhost-party.vercel.app/play`
- [ ] Production: QR code links to correct production URL
- [ ] Scanning QR code on phone navigates to join page

## Fixes

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)