### PR TITLE
fix(ws): resolve @/ path aliases in esbuild for Railway builds

### DIFF
--- a/websocket-server/build.mjs
+++ b/websocket-server/build.mjs
@@ -14,6 +14,8 @@ await esbuild.build({
   format: "esm",
   // Don't bundle node_modules - they'll be installed via npm
   external: ["socket.io", "dotenv"],
+  // Resolve Next.js @/ path aliases (maps to project root = parent dir)
+  alias: { "@": ".." },
   // Preserve environment variable access
   define: {
     "process.env.NODE_ENV": JSON.stringify(


### PR DESCRIPTION
## Summary
- Railway deployment started failing after #71 (multi-game architecture refactor) introduced `@/` path alias imports in `lib/` files
- esbuild in `websocket-server/build.mjs` couldn't resolve Next.js `@/` aliases during Docker builds
- Added `alias: { "@": ".." }` to the esbuild config to map `@/` to the project root

## Failed imports
- `lib/games/pixel-showdown-contract.ts` — `import { DEFAULT_PIXEL_SHOWDOWN_CONFIG } from "@/lib/types/pixel-showdown"`
- `lib/server/core.ts` — `import * as sharedRooms from "@/lib/shared-rooms"`

## Test plan
- [x] Clean local build succeeds (`npm run build` in websocket-server)
- [x] Built output contains zero unresolved `@/lib` references
- [x] All 185 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)